### PR TITLE
fix: caesar cypher encryption to shift forward

### DIFF
--- a/scripts/main_scene.gd
+++ b/scripts/main_scene.gd
@@ -1,34 +1,44 @@
 extends Node2D
-
 signal cypher_changed(new_text)
-
-# TODO: make this typesafe
+	# TODO: make this typesafe
 var keys = Array()
 const scenes = ["res://scenes/levels/tutorial_level_1.tscn"]
 var scene_index = 0;
-
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	load_keys()
 	keys.shuffle()
 	var text: String = keys.pop_back()
+	text = caesar_cipher(text)  # Apply cipher before emitting
 	cypher_changed.emit(text)
 	# NOTE: preload is on compile time and load is at runtime
 	# this should probably be preloaded but it doesn't work with an array
 	var scene = load(scenes[scene_index])
 	var instance = scene.instantiate()
 	add_child(instance)
-
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	pass
-
 func load_keys() -> void:
 	var file = FileAccess.open("res://data/keys.txt", FileAccess.READ)	
 	var content = file.get_as_text();
-
 	for key in content.split("\n"):
 		# strip the \r
 		key = key.strip_escapes()
 		if key.length() > 0:
 			keys.append(key.strip_escapes())
+func caesar_cipher(text: String, shift: int = 5) -> String:
+	var result = ""
+	for i in range(text.length()):
+		var c = text[i]
+		# check if character is a letter
+		if (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z'):
+			var ascii = text.unicode_at(i)
+			var base = 65 if c.to_upper() == c else 97  # handle upper/lowercase
+			# normalize to 0-25 range, shift forward, then convert back
+			var normalized = ascii - base
+			var shifted = (normalized + shift) % 26  # Forward shift
+			result += String.chr(shifted + base)
+		else:
+			result += c
+	return result

--- a/scripts/main_scene.gd
+++ b/scripts/main_scene.gd
@@ -1,9 +1,12 @@
 extends Node2D
+
 signal cypher_changed(new_text)
-	# TODO: make this typesafe
+
+# TODO: make this typesafe
 var keys = Array()
 const scenes = ["res://scenes/levels/tutorial_level_1.tscn"]
-var scene_index = 0;
+var scene_index = 0
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	load_keys()
@@ -16,26 +19,30 @@ func _ready() -> void:
 	var scene = load(scenes[scene_index])
 	var instance = scene.instantiate()
 	add_child(instance)
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	pass
+
 func load_keys() -> void:
 	var file = FileAccess.open("res://data/keys.txt", FileAccess.READ)	
-	var content = file.get_as_text();
+	var content = file.get_as_text()
+
 	for key in content.split("\n"):
 		# strip the \r
 		key = key.strip_escapes()
 		if key.length() > 0:
 			keys.append(key.strip_escapes())
+
 func caesar_cipher(text: String, shift: int = 5) -> String:
 	var result = ""
 	for i in range(text.length()):
 		var c = text[i]
-		# check if character is a letter
+		# Check if character is a letter
 		if (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z'):
 			var ascii = text.unicode_at(i)
-			var base = 65 if c.to_upper() == c else 97  # handle upper/lowercase
-			# normalize to 0-25 range, shift forward, then convert back
+			var base = 65 if c.to_upper() == c else 97  # Handle upper/lowercase
+			# Normalize to 0-25 range, shift forward, then convert back
 			var normalized = ascii - base
 			var shifted = (normalized + shift) % 26  # Forward shift
 			result += String.chr(shifted + base)


### PR DESCRIPTION
Implement Caesar cipher encryption with forward shift by 5 

Adds a proper Caesar cipher implementation to main_scene.gd that:
- shifts letters forward by 5 positions in the alphabet (A→F, B→G, etc.)
- maintains case sensitivity (uppercase stays uppercase)

Example: "Cats" encrypts to "Hfyx"